### PR TITLE
Date/time range convenience

### DIFF
--- a/lib/dt-utils.js
+++ b/lib/dt-utils.js
@@ -1,0 +1,131 @@
+/*
+ Copyright (C) 2017  The University of Sydney Library
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict'
+
+
+/**
+ * A moment object from the moment.js library.
+ * @typedef {object} Moment
+ * @see {@link https://momentjs.com/docs/}
+ */
+
+
+/**
+ * A DateTime object from the Luxon library.
+ * @typedef {object} DateTime
+ * @see {@link http://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html}
+ */
+
+/**
+ * An Interval object from the Luxon library.
+ * @typedef {object} Interval
+ * @see {@link http://moment.github.io/luxon/docs/class/src/interval.js~Interval.html}
+ */
+
+
+/**
+ * Makes a Sierra API date/time range from strings, dates, moments.js moments, Luxon DateTimes, or a Luxon Interval.
+ *
+ * Does not validate the first date/time is earlier in time than the second date/time.
+ *
+ * If you give a string, it is assumed you've given an already a properly formed date/time range, and the arg is simply
+ * returned.
+ *
+ * If the arg is undefined or null, undefined is returned.
+ *
+ * If you give a Luxon Interval, then the two DateTimes inside the Interval are used as to from the date/time range.
+ * HOWEVER, Luxon Intervals do NOT include there endpoint, whereas Sierra API date/time ranges do. The Sierra API only
+ * express date/time down to seconds, and not milliseconds. So 1 second will be subtracted from the Luxon Interval's
+ * exclusive end to make the Sierra API date/time range's inclusive end.
+ *
+ * If you give a native Date, a moment.js moments or a Luxon DateTime (not in array), it is converted into a
+ * ISO 8601 date/time strings in UTC. It is not put inside Sierra's range syntax; thus specifying just the date/time and
+ * not a range of date/times.
+ *
+ * If you give an array, then the first element of the array is taken to be the start of the range and the second
+ * argument is taken to be the end of the range.
+ *
+ * Strings must be simplified extended ISO format date/time strings. They must be in UTC and have a Z zone designator.
+ * Native Dates, moment.js moments and Luxon DateTimes are converted to ISO 8601 date/time strings in UTC for you.
+ *
+ * If the first element of the array is undefined or null, then the range will be left-open.
+ * If the second element of the array is undefined or null, then the range will be right-open.
+ * If the both elements of the array are undefined or null, then undefined is returned.
+ *
+ * @param {(String|Interval|Array.<(Date|Moment|DateTime|undefined|null)>|undefined|null)} range - The date/time range
+ *
+ * @see {@link https://techdocs.iii.com/sierraapi/Content/zReference/queryParameters.htm#range_syntax}.
+ */
+function toDateTimeRange(range) {
+  if (!range) {
+    return
+  }
+
+  if (typeof range === 'string') {
+    return range
+  }
+
+  if (typeof range !== 'object') {
+    throw new Error(`Invalid date/time range: ${range}`)
+  }
+
+  let from
+  let to
+
+  if (Array.isArray(range)) {
+    from = range[0]
+    to = range[1]
+  } else if (typeof range.start === 'object' && typeof range.end === 'object') {
+    from = range.start
+    to = range.end.minus({ second: 1 }) // Luxon Intervals are end-exclusive, but date/time ranges are end-inclusive.
+  } else if (typeof range.toISO === 'function') {
+    return range.toISO()
+  } else {
+    return range.toISOString()
+  }
+
+  if (!from && !to) {
+    return
+  }
+
+  const fromIsoString = _toIsoString(from) || ''
+  const toIsoString = _toIsoString(to) || ''
+  return `[${fromIsoString},${toIsoString}]`
+}
+
+
+function _toIsoString(thing) {
+  if (thing === undefined || thing === null) {
+    return thing
+  }
+  if (typeof thing === 'object') {
+    if (typeof thing.toISO === 'function') {
+      return thing.toISO()
+    }
+    if (typeof thing.toISOString === 'function') {
+      return thing.toISOString()
+    }
+    throw new Error(`Don't know how to convert to an ISO date/time string: ${thing}`)
+  }
+  return String(thing)
+}
+
+
+module.exports = {
+  toDateTimeRange
+}

--- a/lib/dt-utils.js
+++ b/lib/dt-utils.js
@@ -39,7 +39,82 @@
 
 
 /**
- * Makes a Sierra API date/time range from strings, dates, moments.js moments, Luxon DateTimes, or a Luxon Interval.
+ * @typedef {(String|Date|Moment|DateTime|undefined|null)} DateLike
+ */
+
+
+/**
+ * Makes a Sierra API date range from strings, dates, moments.js moments, Luxon DateTimes, or a Luxon Intervals.
+ *
+ * Does not validate the first date/time is earlier in time than the second date/time.
+ *
+ * If you give a string, it is assumed you've given an already a properly formed date range, and the arg is simply
+ * returned.
+ *
+ * If the arg is undefined or null, undefined is returned.
+ *
+ * If you give a Luxon Interval, then the two DateTimes inside the Interval are used as to from the date range. HOWEVER,
+ * Luxon Intervals do NOT include there endpoint, whereas Sierra API date ranges do. So 1 day will be subtracted from
+ * the Luxon Interval's exclusive end to make the Sierra API date/time range's inclusive end.
+ *
+ * If you give a native Date, a moment.js moments or a Luxon DateTime (not in array), it is converted into a
+ * ISO 8601 date string in UTC by truncating any time part. It is not put inside Sierra's range syntax; thus specifying
+ * just the date and not a range of dates.
+ *
+ * If you give an array, then the first element of the array is taken to be the start of the range and the second
+ * argument is taken to be the end of the range.
+ *
+ * Strings must be simplified extended ISO format date strings. Native Dates, moment.js moments and Luxon DateTimes are
+ * converted to ISO 8601 date string in UTC by truncating any time part.
+ *
+ * If the first element of the array is undefined or null, then the range will be left-open.
+ * If the second element of the array is undefined or null, then the range will be right-open.
+ * If the both elements of the array are undefined or null, then undefined is returned.
+ *
+ * @param {(DateLike|Interval|Array.<DateLike>)} range - The date/time range
+ *
+ * @see {@link https://techdocs.iii.com/sierraapi/Content/zReference/queryParameters.htm#range_syntax}.
+ */
+function toDateRange(range) {
+  if (!range) {
+    return
+  }
+
+  if (typeof range === 'string') {
+    return range
+  }
+
+  if (typeof range !== 'object') {
+    throw new Error(`Invalid date/time range: ${range}`)
+  }
+
+  let from
+  let to
+
+  if (Array.isArray(range)) {
+    from = range[0]
+    to = range[1]
+  } else if (typeof range.start === 'object' && typeof range.end === 'object') {
+    from = range.start
+    to = range.end.minus({ day: 1 }) // Luxon Intervals are end-exclusive, but date/time ranges are end-inclusive.
+  } else if (typeof range.toISO === 'function') {
+    return range.toISO().slice(0, 10)
+  } else {
+    return range.toISOString().slice(0, 10)
+  }
+
+  if (!from && !to) {
+    return
+  }
+
+  const fromIsoString = _toIsoString(from) || ''
+  const toIsoString = _toIsoString(to) || ''
+  return `[${fromIsoString.slice(0, 10)},${toIsoString.slice(0, 10)}]`
+}
+
+
+/**
+ * Makes a Sierra API date/time range from strings, dates, moments.js moments, Luxon DateTimes, or a Luxon Intervals.
  *
  * Does not validate the first date/time is earlier in time than the second date/time.
  *
@@ -67,10 +142,11 @@
  * If the second element of the array is undefined or null, then the range will be right-open.
  * If the both elements of the array are undefined or null, then undefined is returned.
  *
- * @param {(String|Interval|Array.<(Date|Moment|DateTime|undefined|null)>|undefined|null)} range - The date/time range
+ * @param {(DateLike|Interval|Array.<DateLike>)} range - The date/time range
  *
  * @see {@link https://techdocs.iii.com/sierraapi/Content/zReference/queryParameters.htm#range_syntax}.
  */
+
 function toDateTimeRange(range) {
   if (!range) {
     return
@@ -127,5 +203,6 @@ function _toIsoString(thing) {
 
 
 module.exports = {
+  toDateRange,
   toDateTimeRange
 }

--- a/lib/test-support.js
+++ b/lib/test-support.js
@@ -82,6 +82,12 @@ const ARBITRARY_ISO_DATE_TIME_STRING = (
   )
 )
 
+const ARBITRARY_ISO_DATE_STRING = (
+  ARBITRARY_TIME.smap(
+    time => new Date(time).toISOString().slice(0, 10),
+  )
+)
+
 
 const ARBITRARY_UNDEFINED_OR_NULL = jsv.oneof([ jsv.constant(undefined), jsv.constant(null) ])
 
@@ -96,6 +102,7 @@ module.exports = {
     dateTime: ARBITRARY_DATETIME,
     moment: ARBITRARY_MOMENT,
     period: ARBITRARY_PERIOD,
+    isoDateString: ARBITRARY_ISO_DATE_STRING,
     isoDateTimeString: ARBITRARY_ISO_DATE_TIME_STRING,
     time: ARBITRARY_TIME,
 

--- a/lib/test-support.js
+++ b/lib/test-support.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017  The University of Sydney Library
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+'use strict'
+
+
+const jsv = require('jsverify')
+const { DateTime } = require('luxon')
+const moment = require('moment')
+
+
+const _DEFAULT_JSV_ASSERT_OPTIONS = Object.freeze({ tests: process.env['JSV_TESTS'] || 100 })
+
+function chaiProperty(...jsverifyPropertyArgs) {
+  const [ name, ...arbs ] = jsverifyPropertyArgs
+  const propCheckFn = arbs.pop()
+  const jsvAssertOptions = (
+    typeof arbs[arbs.length - 1] === 'object'
+    && typeof(arbs[arbs.length - 1].generator) !== 'function'
+      ? Object.assign({}, _DEFAULT_JSV_ASSERT_OPTIONS, arbs.pop())
+      : Object.assign({}, _DEFAULT_JSV_ASSERT_OPTIONS)  // Grr. jsv.assert mutates jsvAssertOptions
+  )
+  it(name, function () {
+    jsv.assert(
+      jsv.forall(...arbs, (...values) => {
+        propCheckFn(...values)
+        return true
+      }),
+      jsvAssertOptions
+    )
+  })
+}
+
+
+
+const MINIMUM_TEST_TIME = 631152000000 // '1990-01-01T00:00:00.000Z'
+const MAXIMUM_TEST_TIME = 2524607999999 // '2049-12-31T23:59:59.999Z'
+
+const ARBITRARY_TIME = jsv.integer(MINIMUM_TEST_TIME, MAXIMUM_TEST_TIME)
+const ARBITRARY_PERIOD = jsv.integer(1, Math.floor((MAXIMUM_TEST_TIME - MINIMUM_TEST_TIME) / 2))
+
+const ARBITRARY_DATE = (
+  ARBITRARY_TIME.smap(
+    time => new Date(time),
+    date => date.getTime()
+  )
+)
+
+const ARBITRARY_DATETIME = (
+  ARBITRARY_TIME.smap(
+    time => DateTime.fromMillis(time),
+    datetime => datetime.valueOf()
+  )
+)
+
+const ARBITRARY_MOMENT = (
+  ARBITRARY_TIME.smap(
+    time => moment(time),
+    moment => moment.valueOf()
+  )
+)
+
+const ARBITRARY_ISO_DATE_TIME_STRING = (
+  ARBITRARY_TIME.smap(
+    time => new Date(time).toISOString(),
+    date => new Date(date).getTime()
+  )
+)
+
+
+const ARBITRARY_UNDEFINED_OR_NULL = jsv.oneof([ jsv.constant(undefined), jsv.constant(null) ])
+
+
+module.exports = {
+
+  chaiProperty,
+
+  arbitrary: {
+
+    date: ARBITRARY_DATE,
+    dateTime: ARBITRARY_DATETIME,
+    moment: ARBITRARY_MOMENT,
+    period: ARBITRARY_PERIOD,
+    isoDateTimeString: ARBITRARY_ISO_DATE_TIME_STRING,
+    time: ARBITRARY_TIME,
+
+    undefinedOrNull: ARBITRARY_UNDEFINED_OR_NULL,
+
+  }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -54,6 +60,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -77,10 +89,46 @@
         "hoek": "4.2.0"
       }
     },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "client-oauth2": {
       "version": "4.1.0",
@@ -103,6 +151,18 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
@@ -112,6 +172,12 @@
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -144,10 +210,34 @@
         "assert-plus": "1.0.0"
       }
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.5"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -157,6 +247,12 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "extend": {
       "version": "3.0.1",
@@ -193,6 +289,18 @@
         "mime-types": "2.1.16"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -200,6 +308,26 @@
       "requires": {
         "assert-plus": "1.0.0"
       }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -215,6 +343,12 @@
         "har-schema": "2.0.0"
       }
     },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -225,6 +359,12 @@
         "hoek": "4.2.0",
         "sntp": "2.1.0"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hoek": {
       "version": "4.2.0",
@@ -239,6 +379,16 @@
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -293,10 +443,37 @@
         "verror": "1.10.0"
       }
     },
+    "jsverify": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/jsverify/-/jsverify-0.8.3.tgz",
+      "integrity": "sha1-AukXjhkktar5WcAjmvhO1cbQc4w=",
+      "dev": true,
+      "requires": {
+        "lazy-seq": "1.0.0",
+        "rc4": "0.1.5",
+        "trampa": "1.0.0",
+        "typify-parser": "1.1.0"
+      }
+    },
+    "lazy-seq": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-seq/-/lazy-seq-1.0.0.tgz",
+      "integrity": "sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "luxon": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-0.0.22.tgz",
+      "integrity": "sha512-FLZ2a9s09xtD8ilF0xuXeJGLEhGclFjx12omAnIrbo33GNR7f6WrBG28/5if5K0KvpMyJLuh7oIlxaraYFBWHg==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.1"
+      }
     },
     "make-error": {
       "version": "1.3.0",
@@ -324,10 +501,85 @@
         "mime-db": "1.29.0"
       }
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "moment": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -359,6 +611,12 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "rc4": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rc4/-/rc4-0.1.5.tgz",
+      "integrity": "sha1-CMbgSgFo9utiHCKrbLEVG9n0pk0=",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -511,6 +769,15 @@
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
@@ -518,6 +785,12 @@
       "requires": {
         "punycode": "1.4.1"
       }
+    },
+    "trampa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trampa/-/trampa-1.0.0.tgz",
+      "integrity": "sha1-Ukc0esM0gH+mwAAERMuRtjmECtU=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -533,10 +806,22 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type-detect": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typify-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",
+      "integrity": "sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -557,6 +842,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
     "client-oauth2": "^4.1.0",
     "request": "^2.83.0",
     "request-promise-any": "^1.0.5"
+  },
+  "devDependencies": {
+    "chai": "*",
+    "jsverify": "^0.8.3",
+    "luxon": "~0.0.22",
+    "mocha": "*",
+    "moment": "^2.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "node": ">=8.9.0"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "dependencies": {
     "@sydneyunilibrary/sierra-record-id": "github:SydneyUniLibrary/sierra-record-id#v0.2.0",
     "client-oauth2": "^4.1.0",

--- a/test/dt-utils.js
+++ b/test/dt-utils.js
@@ -24,7 +24,7 @@ const { Interval } = require('luxon')
 
 const { chaiProperty, arbitrary } = require('../lib/test-support')
 
-const { toDateTimeRange } = require('../lib/dt-utils')
+const { toDateRange, toDateTimeRange } = require('../lib/dt-utils')
 
 
 
@@ -196,5 +196,171 @@ describe('dt-utils', function () {
 
   })
 
+
+  describe('toDateRange', function () {
+
+    it('returns undefined if given undefined, null or empty strings', function () {
+      expect(toDateRange(undefined)).to.be.undefined
+      expect(toDateRange(null)).to.be.undefined
+      expect(toDateRange('')).to.be.undefined
+      expect(toDateRange([])).to.be.undefined
+      expect(toDateRange([undefined, undefined])).to.be.undefined
+      expect(toDateRange([null, null])).to.be.undefined
+      expect(toDateRange(['', ''])).to.be.undefined
+    })
+
+    chaiProperty(
+      'passes through arbitrary non-empty strings',
+      jsv.nestring,
+      ( arg ) => {
+        expect(toDateRange(arg)).to.equal(arg)
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary date as an ISO date string',
+      arbitrary.date,
+      ( arg ) => {
+        expect(toDateRange(arg)).to.equal(arg.toISOString().slice(0, 10))
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary Luxon DateTime as an ISO date/time string',
+      arbitrary.dateTime,
+      ( arg ) => {
+        expect(toDateRange(arg)).to.equal(arg.toISO().slice(0, 10))
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary moment.js moment as an ISO date/time string',
+      arbitrary.moment,
+      ( arg ) => {
+        expect(toDateRange(arg)).to.equal(arg.toISOString().slice(0, 10))
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary ISO strings',
+      arbitrary.isoDateString,
+      arbitrary.isoDateString,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from},${to}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary ISO string',
+      arbitrary.undefinedOrNull,
+      arbitrary.isoDateString,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[,${to}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary ISO string',
+      arbitrary.isoDateString,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary dates',
+      arbitrary.date,
+      arbitrary.date,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISOString().slice(0, 10)},${to.toISOString().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary date',
+      arbitrary.undefinedOrNull,
+      arbitrary.date,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[,${to.toISOString().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary date',
+      arbitrary.date,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISOString().slice(0, 10)},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary Luxon DateTime objects',
+      arbitrary.dateTime,
+      arbitrary.dateTime,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISO().slice(0, 10)},${to.toISO().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary Luxon DateTime',
+      arbitrary.undefinedOrNull,
+      arbitrary.dateTime,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[,${to.toISO().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary Luxon DateTime',
+      arbitrary.dateTime,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISO().slice(0, 10)},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from an arbitrary Luxon Interval object',
+      arbitrary.dateTime,
+      arbitrary.period,
+      ( from, period ) => {
+        const inclusiveTo = from.plus(period)
+        const exclusiveTo = inclusiveTo.plus({ day: 1})
+        const interval = Interval.fromDateTimes(from, exclusiveTo)
+        expect(toDateRange(interval)).to.equal(`[${from.toISO().slice(0, 10)},${inclusiveTo.toISO().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary moment.js moment objects',
+      arbitrary.moment,
+      arbitrary.moment,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISOString().slice(0, 10)},${to.toISOString().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary moment.js moment object',
+      arbitrary.undefinedOrNull,
+      arbitrary.moment,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[,${to.toISOString().slice(0, 10)}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary moment.js moment object',
+      arbitrary.moment,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateRange([from, to])).to.equal(`[${from.toISOString().slice(0, 10)},]`)
+      }
+    )
+
+  })
 
 }) // describe('dt-utils'

--- a/test/dt-utils.js
+++ b/test/dt-utils.js
@@ -1,0 +1,200 @@
+/*
+ Copyright (C) 2017  The University of Sydney Library
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+'use strict'
+
+
+const expect = require('chai').expect
+const jsv = require('jsverify')
+const { Interval } = require('luxon')
+
+const { chaiProperty, arbitrary } = require('../lib/test-support')
+
+const { toDateTimeRange } = require('../lib/dt-utils')
+
+
+
+describe('dt-utils', function () {
+
+  describe('toDateTimeRange', function () {
+
+    it('returns undefined if given undefined, null or empty strings', function () {
+      expect(toDateTimeRange(undefined)).to.be.undefined
+      expect(toDateTimeRange(null)).to.be.undefined
+      expect(toDateTimeRange('')).to.be.undefined
+      expect(toDateTimeRange([])).to.be.undefined
+      expect(toDateTimeRange([undefined, undefined])).to.be.undefined
+      expect(toDateTimeRange([null, null])).to.be.undefined
+      expect(toDateTimeRange(['', ''])).to.be.undefined
+    })
+
+    chaiProperty(
+      'passes through arbitrary non-empty strings',
+      jsv.nestring,
+      ( arg ) => {
+        expect(toDateTimeRange(arg)).to.equal(arg)
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary date as an ISO date/time string',
+      arbitrary.date,
+      ( arg ) => {
+        expect(toDateTimeRange(arg)).to.equal(arg.toISOString())
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary Luxon DateTime as an ISO date/time string',
+      arbitrary.dateTime,
+      ( arg ) => {
+        expect(toDateTimeRange(arg)).to.equal(arg.toISO())
+      }
+    )
+
+    chaiProperty(
+      'formats a single arbitrary moment.js moment as an ISO date/time string',
+      arbitrary.moment,
+      ( arg ) => {
+        expect(toDateTimeRange(arg)).to.equal(arg.toISOString())
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary ISO strings',
+      arbitrary.isoDateTimeString,
+      arbitrary.isoDateTimeString,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from},${to}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary ISO string',
+      arbitrary.undefinedOrNull,
+      arbitrary.isoDateTimeString,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[,${to}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary ISO string',
+      arbitrary.isoDateTimeString,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary dates',
+      arbitrary.date,
+      arbitrary.date,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISOString()},${to.toISOString()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary date',
+      arbitrary.undefinedOrNull,
+      arbitrary.date,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[,${to.toISOString()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary date',
+      arbitrary.date,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISOString()},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary Luxon DateTime objects',
+      arbitrary.dateTime,
+      arbitrary.dateTime,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISO()},${to.toISO()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary Luxon DateTime',
+      arbitrary.undefinedOrNull,
+      arbitrary.dateTime,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[,${to.toISO()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary Luxon DateTime',
+      arbitrary.dateTime,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISO()},]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from an arbitrary Luxon Interval object',
+      arbitrary.dateTime,
+      arbitrary.period,
+      ( from, period ) => {
+        const inclusiveTo = from.plus(period)
+        const exclusiveTo = inclusiveTo.plus({ second: 1})
+        const interval = Interval.fromDateTimes(from, exclusiveTo)
+        expect(toDateTimeRange(interval)).to.equal(`[${from.toISO()},${inclusiveTo.toISO()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a closed range from two arbitrary moment.js moment objects',
+      arbitrary.moment,
+      arbitrary.moment,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISOString()},${to.toISOString()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a left-open range from an arbitrary moment.js moment object',
+      arbitrary.undefinedOrNull,
+      arbitrary.moment,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[,${to.toISOString()}]`)
+      }
+    )
+
+    chaiProperty(
+      'creates a right-open range from an arbitrary moment.js moment object',
+      arbitrary.moment,
+      arbitrary.undefinedOrNull,
+      ( from, to ) => {
+        expect(toDateTimeRange([from, to])).to.equal(`[${from.toISOString()},]`)
+      }
+    )
+
+  })
+
+
+}) // describe('dt-utils'

--- a/v4/patrons.js
+++ b/v4/patrons.js
@@ -18,8 +18,10 @@
 'use strict'
 
 
-const qsUtils = require('../qs-utils')
 const { AbsoluteV4ApiUrl, RecordId, RecordNumber, RelativeV4ApiUrl } = require('@sydneyunilibrary/sierra-record-id')
+
+const { toDateTimeRange } = require('../lib/dt-utils')
+const qsUtils = require('../qs-utils')
 
 
 class SierraPatronApi_v4 {
@@ -37,6 +39,9 @@ class SierraPatronApi_v4 {
 
 
   getPatrons({ limit, offset, id, fields, createdDate, updatedDate, deletedDate, deleted, suppressed } = {}) {
+    createdDate = toDateTimeRange(createdDate)
+    updatedDate = toDateTimeRange(updatedDate)
+    //deletedDate = toDateRange(deletedDate) TODO: Uncomment this once toDateRange is written
     id = qsUtils.joinArray(id)
     fields = qsUtils.joinArray(fields)
     return this.connection.get(
@@ -61,6 +66,7 @@ class SierraPatronApi_v4 {
 
 
   getPatronFines(idOrUrl, { limit, offset, fields, assessedDate } = {}) {
+    assessedDate = toDateTimeRange(assessedDate)
     fields = qsUtils.joinArray(fields)
     const apiUrl = `${this._resolveIdOrUrlToApiUrl(idOrUrl)}/fines`
     return this.connection.get(apiUrl, { limit, offset, fields, assessedDate })

--- a/v4/patrons.js
+++ b/v4/patrons.js
@@ -20,7 +20,7 @@
 
 const { AbsoluteV4ApiUrl, RecordId, RecordNumber, RelativeV4ApiUrl } = require('@sydneyunilibrary/sierra-record-id')
 
-const { toDateTimeRange } = require('../lib/dt-utils')
+const { toDateRange, toDateTimeRange } = require('../lib/dt-utils')
 const qsUtils = require('../qs-utils')
 
 
@@ -41,7 +41,7 @@ class SierraPatronApi_v4 {
   getPatrons({ limit, offset, id, fields, createdDate, updatedDate, deletedDate, deleted, suppressed } = {}) {
     createdDate = toDateTimeRange(createdDate)
     updatedDate = toDateTimeRange(updatedDate)
-    //deletedDate = toDateRange(deletedDate) TODO: Uncomment this once toDateRange is written
+    deletedDate = toDateRange(deletedDate)
     id = qsUtils.joinArray(id)
     fields = qsUtils.joinArray(fields)
     return this.connection.get(


### PR DESCRIPTION
For range-capable date/time parameters, in addition to giving an ISO string or a range string, support passing an array of two: ISO strings, native Date objects, moment.js moment objects
or Luxon DateTime objects.

Also support passing in a Luxon Interval object, and adjusting for the end of Luxon Interval objects being exclusive but the end of Sierra API ranges being inclusive.

Support open-ended ranges.

This doesn't create a dependency on either  the moment.js or Luxon libraries. Duck-typing is used to detect moement.js and Luxon objects and convert them to ISO strings. There is a dev dependency on these in order to use these objects for testing.